### PR TITLE
群馬追加

### DIFF
--- a/Assignment_04.html
+++ b/Assignment_04.html
@@ -13,6 +13,10 @@
 			<td>新潟</td>
 			<td>新潟</td>
 		</tr>
+		<tr>
+			<td>群馬</td>
+			<td>前橋</td>
+		</tr>
 	</table>
 </body>
 </html>


### PR DESCRIPTION
県名、県庁所在地の項目に群馬、前橋を追加